### PR TITLE
fix issue #7 and #4

### DIFF
--- a/main.c
+++ b/main.c
@@ -156,18 +156,13 @@ void main() {
                     break;
                 }
 
-                if (is_drive_requested()) {
-                    // Driver just flipped drive switch
-                    // Give driver some time to press brake
-                    __delay_ms(DRIVE_REQ_DELAY_MS);
-                    
-                    // Now check
-                    if (get_brake_pedal_value() >= PEDAL_MAX - BRAKE_ERROR_TOLERANCE) {
-                        // Brake pressed
+                if (get_brake_pedal_value() >= PEDAL_MAX - BRAKE_ERROR_TOLERANCE) {
+                    // Driver pressed break 
+                    // Need to also flip on drive switch to drive
+                    if (is_drive_requested()) {
+                        // Drive switch flipped on
+                        // Go to drive
                         change_state(DRIVE);                        
-                    } else {
-                        // Brake not pressed
-                        report_fault(BRAKE_NOT_PRESSED);
                     }
                 }
                 break;
@@ -182,7 +177,6 @@ void main() {
                 if (!is_hv_requested()) {
                     // HV switched flipped off, so can't drive
                     report_fault(HV_DISABLED_WHILE_DRIVE);
-                    break;
                 }
                 break;
             case FAULT:

--- a/main.c
+++ b/main.c
@@ -17,7 +17,7 @@ typedef enum {
     NONE,
     DRIVE_REQUEST_FROM_LV,
     CONSERVATIVE_TIMER_MAXED,
-    BRAKE_NOT_PRESSED,
+    /*BRAKE_NOT_PRESSED,*/
     HV_DISABLED_WHILE_DRIVE
 } error_t;
 
@@ -66,7 +66,7 @@ state_t state = LV;
 error_t error = NONE;
 
 const char* STATE_NAMES[] = {"LV", "PRECHARGING", "HV_ENABLED", "DRIVE", "FAULT"};
-const char* ERROR_NAMES[] = {"NONE", "DRIVE_REQUEST_FROM_LV", "CONSERVATIVE_TIMER_MAXED", "BRAKE_NOT_PRESSED", "HV_DISABLED_WHILE_DRIVE"};
+const char* ERROR_NAMES[] = {"NONE", "DRIVE_REQUEST_FROM_LV", "CONSERVATIVE_TIMER_MAXED", /*"BRAKE_NOT_PRESSED",*/ "HV_DISABLED_WHILE_DRIVE"};
 
 void change_state(const state_t new_state) {
     // Handle edge cases
@@ -195,10 +195,15 @@ void main() {
                             change_state(LV);
                         }
                         break;
-                    case BRAKE_NOT_PRESSED:
-                        if (!is_drive_requested()) {
-                            // Ask driver to reset drive switch and try again
-                            change_state(HV_ENABLED);
+                    // case BRAKE_NOT_PRESSED:
+                    //     if (!is_drive_requested()) {
+                    //         // Ask driver to reset drive switch and try again
+                    //         change_state(HV_ENABLED);
+                    //     }
+                    //     break;
+                    case HV_DISABLED_WHILE_DRIVE:
+                        if (is_hv_requested()) {
+                            change_state(DRIVE);
                         }
                         break;
                 }

--- a/main.c
+++ b/main.c
@@ -17,7 +17,8 @@ typedef enum {
     NONE,
     DRIVE_REQUEST_FROM_LV,
     CONSERVATIVE_TIMER_MAXED,
-    BRAKE_NOT_PRESSED
+    BRAKE_NOT_PRESSED,
+    HV_DISABLED_WHILE_DRIVE
 } error_t;
 
 // Controls
@@ -65,7 +66,7 @@ state_t state = LV;
 error_t error = NONE;
 
 const char* STATE_NAMES[] = {"LV", "PRECHARGING", "HV_ENABLED", "DRIVE", "FAULT"};
-const char* ERROR_NAMES[] = {"NONE", "DRIVE_REQUEST_FROM_LV", "CONSERVATIVE_TIMER_MAXED", "BRAKE_NOT_PRESSED"};
+const char* ERROR_NAMES[] = {"NONE", "DRIVE_REQUEST_FROM_LV", "CONSERVATIVE_TIMER_MAXED", "BRAKE_NOT_PRESSED", "HV_DISABLED_WHILE_DRIVE"};
 
 void change_state(const state_t new_state) {
     // Handle edge cases
@@ -175,6 +176,13 @@ void main() {
                     // Drive switch was flipped off
                     // Revert to HV
                     change_state(HV_ENABLED);
+                   break;
+                }
+
+                if (!is_hv_requested()) {
+                    // HV switched flipped off, so can't drive
+                    report_fault(HV_DISABLED_WHILE_DRIVE);
+                    break;
                 }
                 break;
             case FAULT:


### PR DESCRIPTION
fixes #7, now throws fault when HV_enabled switch is flipped off during drive state
fixes #4, pressing brake and enabling drive switch now immediately change to drive mode